### PR TITLE
Remove user scope from OAuth authorization

### DIFF
--- a/web/oauth2/github.ex
+++ b/web/oauth2/github.ex
@@ -25,7 +25,7 @@ defmodule GitHub do
   end
 
   def authorize_url!(params \\ []) do
-    OAuth2.Client.authorize_url!(client(), Keyword.merge(params, scope: "user,read:org"))
+    OAuth2.Client.authorize_url!(client(), Keyword.merge(params, scope: "read:org"))
   end
 
   def get_token!(params \\ [], _headers \\ []) do


### PR DESCRIPTION
User scope grants read and _write_ access. This wasn't intentional.

/cc @arcanemagus Thanks :heart: