### PR TITLE
Log exceptions instead of report outside of prod

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -52,6 +52,7 @@ config :slime, :embedded_engines, %{
 
 config :rollbax,
   access_token: System.get_env("ROLLBAR_SERVER_TOKEN"),
+  enabled: :log,
   environment: Mix.env
 
 # Import environment specific config. This must remain at the bottom

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -64,3 +64,5 @@ config :atom_style_tweaks, AtomStyleTweaks.Repo,
 #
 #     config :atom_style_tweaks, AtomStyleTweaks.Endpoint, server: true
 #
+
+config :rollbax, enabled: true


### PR DESCRIPTION
Only prod will report exceptions to Rollbar, all other environments will simply log errors.