### PR TITLE
Force rebuild always because Slime is weird

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -3,3 +3,5 @@ erlang_version=20.0
 
 # Elixir version
 elixir_version=1.5.1
+
+always_rebuild=true


### PR DESCRIPTION
Whenever you change an embedded engine in Slime, you have to do a clean build. While this will make Heroku deploys take significantly longer, I think this will save a lot of aggravation in the long run.