### PR TITLE
Do not report NoRouteErrors

### DIFF
--- a/lib/atom_style_tweaks_web/router.ex
+++ b/lib/atom_style_tweaks_web/router.ex
@@ -5,6 +5,7 @@ defmodule AtomStyleTweaksWeb.Router do
   require Logger
 
   alias AtomStyleTweaksWeb.SlidingSessionTimeout
+  alias Phoenix.Router.NoRouteError
   alias Plug.Conn
 
   pipeline :browser do
@@ -69,6 +70,8 @@ defmodule AtomStyleTweaksWeb.Router do
 
     conn
   end
+
+  defp handle_errors(_, %{kind: :error, reason: %NoRouteError{}}), do: :ok
 
   defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do
     conn =


### PR DESCRIPTION
It's interesting to see what people are randomly hitting but since they always result in a 404 being returned, they shouldn't be taking up the limited number of error reports I'm allowed per month.