### PR TITLE
Enforce consistent formatting

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -122,11 +122,7 @@
         {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
 
         # Deprecated checks (these will be deleted after a grace period)
-        {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Warning.NameRedeclarationByAssignment, false},
-        {Credo.Check.Warning.NameRedeclarationByCase, false},
-        {Credo.Check.Warning.NameRedeclarationByDef, false},
-        {Credo.Check.Warning.NameRedeclarationByFn, false},
+        {Credo.Check.Readability.Specs, false}
 
         # Custom checks can be created using `mix credo.gen.check`.
         #

--- a/script/cibuild
+++ b/script/cibuild
@@ -15,6 +15,8 @@ mix ecto.ci
 
 echo "==> App is now ready to go!"
 
+mix format --check-formatted
+
 if [ -n "$TRAVIS" ]; then
   mix coveralls.travis
 else

--- a/script/test
+++ b/script/test
@@ -28,6 +28,14 @@ else
   script/update
 fi
 
+echo "==> Checking format…"
+
+mix format --check-formatted
+
+echo "==> Running linter…"
+
+mix credo
+
 echo "==> Running tests…"
 
 if [ -n "$1" ]; then

--- a/test/atom_tweaks/ecto/markdown_test.exs
+++ b/test/atom_tweaks/ecto/markdown_test.exs
@@ -9,8 +9,7 @@ defmodule AtomTweaks.Ecto.MarkdownTest do
     end
 
     test "a Markdown struct returns the struct" do
-      {:ok, %AtomTweaks.Markdown{} = markdown} =
-        Markdown.cast(%AtomTweaks.Markdown{text: "test"})
+      {:ok, %AtomTweaks.Markdown{} = markdown} = Markdown.cast(%AtomTweaks.Markdown{text: "test"})
 
       assert markdown.text == "test"
       assert is_nil(markdown.html)

--- a/test/atom_tweaks_web/heroku_metadata_test.exs
+++ b/test/atom_tweaks_web/heroku_metadata_test.exs
@@ -21,13 +21,13 @@ defmodule AtomTweaksWeb.HerokuMetadataTest do
         "HEROKU_SLUG_DESCRIPTION"
       ]
 
-      Enum.each(environment_variable_names, fn(name) ->
+      Enum.each(environment_variable_names, fn name ->
         System.put_env(name, "#{name} test")
       end)
 
-      on_exit fn ->
-        Enum.each(environment_variable_names, fn(name) -> System.delete_env(name) end)
-      end
+      on_exit(fn ->
+        Enum.each(environment_variable_names, fn name -> System.delete_env(name) end)
+      end)
 
       {:ok, env_names: environment_variable_names}
     end
@@ -36,9 +36,10 @@ defmodule AtomTweaksWeb.HerokuMetadataTest do
       metadata = HerokuMetadata.get()
 
       assert length(metadata) == 7
-      assert Enum.all?(context.env_names, fn(name) ->
-        Enum.member?(metadata, [name: name, content: "#{name} test"])
-      end)
+
+      assert Enum.all?(context.env_names, fn name ->
+               Enum.member?(metadata, name: name, content: "#{name} test")
+             end)
     end
 
     test "when only is given", _context do
@@ -46,9 +47,10 @@ defmodule AtomTweaksWeb.HerokuMetadataTest do
       metadata = HerokuMetadata.get(only: only)
 
       assert length(metadata) == 2
-      assert Enum.all?(only, fn(name) ->
-        Enum.member?(metadata, [name: name, content: "#{name} test"])
-      end)
+
+      assert Enum.all?(only, fn name ->
+               Enum.member?(metadata, name: name, content: "#{name} test")
+             end)
     end
 
     test "when except is given", _context do
@@ -56,9 +58,10 @@ defmodule AtomTweaksWeb.HerokuMetadataTest do
       metadata = HerokuMetadata.get(except: except)
 
       assert length(metadata) == 5
-      assert Enum.all?(except, fn(name) ->
-        not Enum.member?(metadata, [name: name, content: "#{name} test"])
-      end)
+
+      assert Enum.all?(except, fn name ->
+               not Enum.member?(metadata, name: name, content: "#{name} test")
+             end)
     end
   end
 end

--- a/test/atom_tweaks_web/markdown_engine_test.exs
+++ b/test/atom_tweaks_web/markdown_engine_test.exs
@@ -55,23 +55,27 @@ defmodule AtomTweaksWeb.MarkdownEngineTest do
 
     test "returns text without mentions unchanged", context do
       assert MarkdownEngine.replace_mention(context.no_mentions, context.funcs) ==
-        context.no_mentions
+               context.no_mentions
     end
 
     test "replaces mentions that are handled by a function", context do
-      assert MarkdownEngine.replace_mention(context.tweaks_mention, context.funcs) == "This text has a tweaks-replacement in it"
+      assert MarkdownEngine.replace_mention(context.tweaks_mention, context.funcs) ==
+               "This text has a tweaks-replacement in it"
     end
 
     test "replaces mentions that are handled by any function in the list", context do
-      assert MarkdownEngine.replace_mention(context.github_mention, context.funcs) == "This text has a github-replacement in it"
+      assert MarkdownEngine.replace_mention(context.github_mention, context.funcs) ==
+               "This text has a github-replacement in it"
     end
 
     test "replaces mentions with the earliest matching function", context do
-      assert MarkdownEngine.replace_mention(context.both_mention, context.funcs) == "This text has a tweaks-replacement in it"
+      assert MarkdownEngine.replace_mention(context.both_mention, context.funcs) ==
+               "This text has a tweaks-replacement in it"
     end
 
     test "does not call later functions if an earlier one matches", context do
-      assert MarkdownEngine.replace_mention(context.tweaks_mention, [&tweaks/2, &bad_func/2]) == "This text has a tweaks-replacement in it"
+      assert MarkdownEngine.replace_mention(context.tweaks_mention, [&tweaks/2, &bad_func/2]) ==
+               "This text has a tweaks-replacement in it"
     end
   end
 end

--- a/test/atom_tweaks_web/page_metadata_test.exs
+++ b/test/atom_tweaks_web/page_metadata_test.exs
@@ -20,7 +20,10 @@ defmodule AtomTweaksWeb.PageMetadataTest do
   end
 
   defp render_fixup(nil), do: nil
-  defp render_fixup(list) when is_list(list), do: Enum.reduce(list, "", fn(safe, acc) -> "#{acc} #{HTML.safe_to_string(safe)}" end)
+
+  defp render_fixup(list) when is_list(list),
+    do: Enum.reduce(list, "", fn safe, acc -> "#{acc} #{HTML.safe_to_string(safe)}" end)
+
   defp render_fixup(safe), do: HTML.safe_to_string(safe)
 
   describe "add" do
@@ -40,27 +43,31 @@ defmodule AtomTweaksWeb.PageMetadataTest do
       metadata = add_metadata(context.conn, [])
 
       assert length(metadata) == 2
-      assert Enum.member?(metadata, [property: "og:url", content: "http://www.example.com/"])
-      assert Enum.member?(metadata, [property: "og:site_name", content: "Atom Tweaks"])
+      assert Enum.member?(metadata, property: "og:url", content: "http://www.example.com/")
+      assert Enum.member?(metadata, property: "og:site_name", content: "Atom Tweaks")
     end
 
     test "has all expected values when something is added", context do
-      metadata = add_metadata(context.conn, [property: "og:title", content: "Test title"])
+      metadata = add_metadata(context.conn, property: "og:title", content: "Test title")
 
       assert length(metadata) == 3
-      assert Enum.member?(metadata, [property: "og:url", content: "http://www.example.com/"])
-      assert Enum.member?(metadata, [property: "og:site_name", content: "Atom Tweaks"])
-      assert Enum.member?(metadata, [property: "og:title", content: "Test title"])
+      assert Enum.member?(metadata, property: "og:url", content: "http://www.example.com/")
+      assert Enum.member?(metadata, property: "og:site_name", content: "Atom Tweaks")
+      assert Enum.member?(metadata, property: "og:title", content: "Test title")
     end
 
     test "has all the expected values when a list is added", context do
-      metadata = add_metadata(context.conn, [[property: "og:title", content: "Test title"], [foo: "bar", bar: "baz"]])
+      metadata =
+        add_metadata(context.conn, [
+          [property: "og:title", content: "Test title"],
+          [foo: "bar", bar: "baz"]
+        ])
 
       assert length(metadata) == 4
-      assert Enum.member?(metadata, [property: "og:url", content: "http://www.example.com/"])
-      assert Enum.member?(metadata, [property: "og:site_name", content: "Atom Tweaks"])
-      assert Enum.member?(metadata, [property: "og:title", content: "Test title"])
-      assert Enum.member?(metadata, [foo: "bar", bar: "baz"])
+      assert Enum.member?(metadata, property: "og:url", content: "http://www.example.com/")
+      assert Enum.member?(metadata, property: "og:site_name", content: "Atom Tweaks")
+      assert Enum.member?(metadata, property: "og:title", content: "Test title")
+      assert Enum.member?(metadata, foo: "bar", bar: "baz")
     end
   end
 

--- a/test/atom_tweaks_web/sliding_session_timeout_test.exs
+++ b/test/atom_tweaks_web/sliding_session_timeout_test.exs
@@ -25,11 +25,11 @@ defmodule AtomTweaksWeb.SlidingSessionTimeoutTest do
 
   describe "when a timeout exists in the config" do
     setup do
-      Application.put_env(:atom_tweaks, SlidingSessionTimeout, [timeout: 5_000])
+      Application.put_env(:atom_tweaks, SlidingSessionTimeout, timeout: 5_000)
 
-      on_exit fn ->
+      on_exit(fn ->
         Application.put_env(:atom_tweaks, SlidingSessionTimeout, nil)
-      end
+      end)
     end
 
     test "uses the configuration value", _context do


### PR DESCRIPTION
Add format checking to both `script/test` and `script/cibuild`.