### PR TITLE
Simpler markdown

### DIFF
--- a/lib/atom_tweaks_web/models/tweak.ex
+++ b/lib/atom_tweaks_web/models/tweak.ex
@@ -5,6 +5,7 @@ defmodule AtomTweaksWeb.Tweak do
 
   use AtomTweaksWeb, :model
 
+  alias AtomTweaks.Ecto.Markdown
   alias AtomTweaksWeb.Tweak
 
   @type t :: %Tweak{}
@@ -15,7 +16,7 @@ defmodule AtomTweaksWeb.Tweak do
     field(:title, :string)
     field(:code, :string)
     field(:type, :string)
-    field(:description, :string)
+    field(:description, Markdown)
     belongs_to(:user, AtomTweaksWeb.User, foreign_key: :created_by, type: :binary_id)
 
     timestamps()

--- a/lib/atom_tweaks_web/templates/tweak/show.html.slime
+++ b/lib/atom_tweaks_web/templates/tweak/show.html.slime
@@ -13,4 +13,4 @@
     = render("copy_tweak_button.html", assigns)
   = render_code(@tweak)
   .tweak-description.markdown-body
-    = render_markdown(@tweak.description)
+    = @tweak.description

--- a/lib/atom_tweaks_web/views/render_helpers.ex
+++ b/lib/atom_tweaks_web/views/render_helpers.ex
@@ -6,7 +6,6 @@ defmodule AtomTweaksWeb.RenderHelpers do
 
   use Phoenix.HTML
 
-  alias AtomTweaksWeb.MarkdownEngine
   alias AtomTweaksWeb.Tweak
 
   @doc """
@@ -18,12 +17,6 @@ defmodule AtomTweaksWeb.RenderHelpers do
       content_tag(:code, tweak.code, class: code_class_for(tweak), id: "code")
     end
   end
-
-  @doc """
-  Renders the given Markdown text into HTML.
-  """
-  @spec render_markdown(String.t()) :: Phoenix.HTML.safe()
-  def render_markdown(text), do: raw(MarkdownEngine.render(text, []))
 
   @doc """
   Renders the template if the condition is truthy.

--- a/test/atom_tweaks_web/controllers/page_controller_test.exs
+++ b/test/atom_tweaks_web/controllers/page_controller_test.exs
@@ -91,7 +91,11 @@ defmodule AtomTweaksWeb.PageControllerTest do
       assigned_tweaks = fetch_assign(context.conn, :tweaks)
 
       assert Enum.count(assigned_tweaks) == 3
-      assert Enum.all?(context.tweaks, &Enum.find(assigned_tweaks, fn(item) -> item.id == &1.id end))
+
+      assert Enum.all?(
+               context.tweaks,
+               &Enum.find(assigned_tweaks, fn item -> item.id == &1.id end)
+             )
     end
 
     test "displays the links to each tweak", context do

--- a/test/atom_tweaks_web/controllers/page_controller_test.exs
+++ b/test/atom_tweaks_web/controllers/page_controller_test.exs
@@ -91,7 +91,7 @@ defmodule AtomTweaksWeb.PageControllerTest do
       assigned_tweaks = fetch_assign(context.conn, :tweaks)
 
       assert Enum.count(assigned_tweaks) == 3
-      assert Enum.all?(context.tweaks, &Enum.member?(assigned_tweaks, &1))
+      assert Enum.all?(context.tweaks, &Enum.find(assigned_tweaks, fn(item) -> item.id == &1.id end))
     end
 
     test "displays the links to each tweak", context do
@@ -117,7 +117,7 @@ defmodule AtomTweaksWeb.PageControllerTest do
       assigned_tweaks = fetch_assign(context.conn, :tweaks)
 
       assert Enum.count(assigned_tweaks) == 1
-      assert Enum.member?(assigned_tweaks, context.tweak)
+      assert hd(assigned_tweaks).id == context.tweak.id
     end
 
     test "displays only the style tweak link", context do
@@ -144,7 +144,7 @@ defmodule AtomTweaksWeb.PageControllerTest do
       assigned_tweaks = fetch_assign(context.conn, :tweaks)
 
       assert Enum.count(assigned_tweaks) == 1
-      assert Enum.member?(assigned_tweaks, context.tweak)
+      assert hd(assigned_tweaks).id == context.tweak.id
     end
 
     test "displays only the init tweak link", context do

--- a/test/atom_tweaks_web/controllers/tweak_controller_test.exs
+++ b/test/atom_tweaks_web/controllers/tweak_controller_test.exs
@@ -226,7 +226,7 @@ defmodule AtomTweaksWeb.TweakControllerTest do
         |> html_response(:ok)
         |> find(".tweak-description")
 
-      assert text(description) == context.tweak.description
+      assert text(description) == context.tweak.description.text
     end
 
     test "does not show the edit button", context do
@@ -261,7 +261,7 @@ defmodule AtomTweaksWeb.TweakControllerTest do
         |> html_response(:ok)
         |> find(".tweak-description")
 
-      assert text(description) == context.tweak.description
+      assert text(description) == context.tweak.description.text
     end
 
     test "shows the edit button", context do
@@ -296,7 +296,7 @@ defmodule AtomTweaksWeb.TweakControllerTest do
         |> html_response(:ok)
         |> find(".tweak-description")
 
-      assert text(description) == context.tweak.description
+      assert text(description) == context.tweak.description.text
     end
 
     test "does not show the edit button", context do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,8 @@ defmodule AtomTweaks.Factory do
 
   alias FakerElixir, as: Faker
 
+  alias AtomTweaks.Markdown
+
   alias AtomTweaksWeb.Tweak
   alias AtomTweaksWeb.User
 
@@ -19,7 +21,7 @@ defmodule AtomTweaks.Factory do
     %Tweak{
       title: Faker.Lorem.words(2..4),
       code: "atom-text-editor { font-style: normal; }",
-      description: Faker.Lorem.sentences(),
+      description: %Markdown{text: Faker.Lorem.sentences()},
       type: "style",
       user: build(:user)
     }


### PR DESCRIPTION
This uses an Ecto type to convert to/from a string in the database to a rich Markdown type in memory. This then simplifies the view logic to not require explicit rendering.