### PR TITLE
Fix up the description field in the tweak edit form

### DIFF
--- a/lib/atom_tweaks_web.ex
+++ b/lib/atom_tweaks_web.ex
@@ -63,6 +63,7 @@ defmodule AtomTweaksWeb do
       import AtomTweaksWeb.AvatarHelpers
       import AtomTweaksWeb.FormHelpers
       import AtomTweaksWeb.MenuHelpers
+      import AtomTweaksWeb.PrimerHelpers
       import AtomTweaksWeb.OcticonHelpers
       import AtomTweaksWeb.RenderHelpers
       import AtomTweaksWeb.TimeHelpers

--- a/lib/atom_tweaks_web/controllers/tweak_controller.ex
+++ b/lib/atom_tweaks_web/controllers/tweak_controller.ex
@@ -55,7 +55,7 @@ defmodule AtomTweaksWeb.TweakController do
       |> Repo.get(id)
       |> Repo.preload([:user])
 
-    changeset = Tweak.changeset(%Tweak{})
+    changeset = Tweak.changeset(tweak)
 
     render(
       conn,

--- a/lib/atom_tweaks_web/templates/tweak/edit.html.slime
+++ b/lib/atom_tweaks_web/templates/tweak/edit.html.slime
@@ -1,12 +1,9 @@
 = form_for @changeset, user_tweak_path(@conn, :update, @name, @tweak.id), [method: "PUT"], fn f ->
-  = form_group(@errors, :title) do
-    = text_input(f, :title, class: "form-control input-block input-lg", placeholder: "Title", value: @tweak.title)
-  = form_group(@errors, :type) do
-    = select(f, :type, ["Init": "init", "Style": "style"], prompt: "Select tweak type", value: @tweak.type)
-  = form_group(@errors, :code) do
-    = textarea(f, :code, class: "form-control input-block tweak-textarea", placeholder: "Enter tweak code", value: @tweak.code)
-  = form_group(@errors, :description) do
-    = textarea(f, :description, class: "form-control input-block description-textarea", placeholder: "Describe the tweak", value: @tweak.description || "")
+  = input(f, :title, placeholder: gettext("Title"), class: "input-lg")
+  = input(f, :type, using: :tweak_type)
+  = input(f, :code, using: :textarea, class: "tweak-textarea", placeholder: "Enter tweak code")
+  = input(f, :description, using: :markdown, class: "description-textarea", placeholder: "Describe the tweak")
+
   .form-actions
-    = submit("Update tweak", class: "btn btn-primary")
-    a.btn.btn-danger href="#{user_tweak_path(@conn, :show, @name, @tweak.id)}" = gettext "Cancel"
+    = submit(gettext("Update tweak"), class: "btn btn-primary")
+    = link_button(gettext("Cancel"), class: "btn btn-danger", to: user_tweak_path(@conn, :show, @name, @tweak.id))

--- a/lib/atom_tweaks_web/views/form_helpers.ex
+++ b/lib/atom_tweaks_web/views/form_helpers.ex
@@ -4,6 +4,9 @@ defmodule AtomTweaksWeb.FormHelpers do
   """
   use Phoenix.HTML
 
+  alias Phoenix.HTML.Form
+
+  alias AtomTweaks.Markdown
   alias AtomTweaksWeb.ErrorHelpers
 
   def form_group(errors, field, do: block),
@@ -22,6 +25,78 @@ defmodule AtomTweaksWeb.FormHelpers do
         content_tag(:dd, ErrorHelpers.translate_error(error), class: "error")
       ]
     end
+  end
+
+  def input(form, field, options \\ []) do
+    type = options[:using] || Form.input_type(form, field)
+
+    wrapper_opts = [class: "form-group #{error_class(form, field)}"]
+    label_opts = []
+
+    input_opts =
+      options
+      |> Keyword.split([:class, :placeholder])
+      |> Tuple.to_list()
+      |> hd()
+      |> Keyword.update(:class, "form-control", &"form-control #{&1}")
+
+    content_tag :dl, wrapper_opts do
+      label =
+        content_tag :dt do
+          label(form, humanize(field), label_opts)
+        end
+
+      input =
+        content_tag :dd do
+          input(type, form, field, input_opts)
+        end
+
+      error = error_tag(form, field) || ""
+
+      [label, input, error]
+    end
+  end
+
+  defp input(:markdown, form, field, input_opts) do
+    content =
+      case Form.input_value(form, field) do
+        nil -> nil
+        %Markdown{} = markdown -> markdown.text
+        value -> value
+      end
+
+    opts =
+      input_opts
+      |> Keyword.merge(id: Form.input_id(form, field), name: Form.input_name(form, field))
+      |> Keyword.put(:class, (input_opts[:class] || "") <> " image-drop")
+
+    content_tag(:textarea, "#{content}\n", opts)
+  end
+
+  defp input(:tweak_type, form, field, _input_opts) do
+    selected = Form.input_value(form, field)
+
+    select(form, field, [Init: "init", Style: "style"], selected: selected)
+  end
+
+  defp input(type, form, field, input_opts) do
+    apply(Form, type, [form, field, input_opts])
+  end
+
+  defp error_class(form, field) do
+    cond do
+      !form.source.action -> ""
+      form.errors[field] -> "errored"
+      true -> ""
+    end
+  end
+
+  defp error_tag(form, field) do
+    Enum.map(Keyword.get_values(form.errors, field), fn error ->
+      content_tag :dd, class: "error" do
+        ErrorHelpers.translate_error(error)
+      end
+    end)
   end
 
   defp errors_for_field(nil, _), do: []

--- a/lib/atom_tweaks_web/views/primer_helpers.ex
+++ b/lib/atom_tweaks_web/views/primer_helpers.ex
@@ -1,0 +1,19 @@
+defmodule AtomTweaksWeb.PrimerHelpers do
+  @moduledoc """
+  Helper functions for generating elements that work with [Primer](https://primer.github.io/).
+  """
+  use Phoenix.HTML
+
+  @doc """
+  Generates a link button with the given text and options.
+
+  ## Options
+
+  * **required** `:to` -- the URL to link to
+  """
+  def link_button(text, options \\ []) do
+    options = Keyword.merge(options, type: "button")
+
+    link(text, options)
+  end
+end


### PR DESCRIPTION
The Markdown simplification PR #149 broke editing of tweak records. This fixes it back up again.