### PR TITLE
Migrate models to schemas

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,2 +1,2 @@
-alias AtomTweaksWeb.Tweak
-alias AtomTweaksWeb.User
+alias AtomTweaks.Tweak
+alias AtomTweaks.User

--- a/lib/atom_tweaks/ecto/markdown.ex
+++ b/lib/atom_tweaks/ecto/markdown.ex
@@ -6,7 +6,7 @@ defmodule AtomTweaks.Ecto.Markdown do
   Use this as the type of the database field in the schema:
 
   ```
-  defmodule AtomTweaksWeb.Tweak do
+  defmodule AtomTweaks.Tweak do
     use Ecto.Schema
     alias AtomTweaks.Ecto.Markdown
 
@@ -15,7 +15,7 @@ defmodule AtomTweaks.Ecto.Markdown do
       field :code, :string
       field :type, :string
       field :description, Markdown
-      belongs_to :user, AtomTweaksWeb.User, foreign_key: :created_by, type: :binary_id
+      belongs_to :user, AtomTweaks.User, foreign_key: :created_by, type: :binary_id
 
       timestamps()
     end

--- a/lib/atom_tweaks/tweak.ex
+++ b/lib/atom_tweaks/tweak.ex
@@ -1,14 +1,15 @@
-defmodule AtomTweaksWeb.Tweak do
+defmodule AtomTweaks.Tweak do
   @moduledoc """
   Represents a tweak.
   """
+  use Ecto.Schema
 
-  use AtomTweaksWeb, :model
+  import Ecto.Changeset
+  import Ecto.Query
 
   alias AtomTweaks.Ecto.Markdown
-  alias AtomTweaksWeb.Tweak
-
-  @type t :: %Tweak{}
+  alias AtomTweaks.Tweak
+  alias AtomTweaks.User
 
   @primary_key {:id, :binary_id, autogenerate: true}
 
@@ -17,7 +18,8 @@ defmodule AtomTweaksWeb.Tweak do
     field(:code, :string)
     field(:type, :string)
     field(:description, Markdown)
-    belongs_to(:user, AtomTweaksWeb.User, foreign_key: :created_by, type: :binary_id)
+
+    belongs_to(:user, User, foreign_key: :created_by, type: :binary_id)
 
     timestamps()
   end

--- a/lib/atom_tweaks/user.ex
+++ b/lib/atom_tweaks/user.ex
@@ -1,14 +1,14 @@
-defmodule AtomTweaksWeb.User do
+defmodule AtomTweaks.User do
   @moduledoc """
   Represents a user of the application.
   """
+  use Ecto.Schema
 
-  use AtomTweaksWeb, :model
+  import Ecto.Changeset
+  import Ecto.Query
 
   alias AtomTweaks.Repo
-  alias AtomTweaksWeb.User
-
-  @type t :: %User{}
+  alias AtomTweaks.User
 
   @derive {Phoenix.Param, key: :name}
 

--- a/lib/atom_tweaks_web.ex
+++ b/lib/atom_tweaks_web.ex
@@ -15,18 +15,6 @@ defmodule AtomTweaksWeb do
   Do NOT define functions inside the quoted expressions
   below.
   """
-
-  def model do
-    quote do
-      use Ecto.Schema
-
-      alias AtomTweaks.Repo
-      import Ecto
-      import Ecto.Changeset
-      import Ecto.Query
-    end
-  end
-
   def controller do
     quote do
       use Phoenix.Controller, namespace: AtomTweaksWeb

--- a/lib/atom_tweaks_web/controllers/auth_controller.ex
+++ b/lib/atom_tweaks_web/controllers/auth_controller.ex
@@ -8,7 +8,7 @@ defmodule AtomTweaksWeb.AuthController do
 
   alias OAuth2.Client, as: OAuthClient
 
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.User
 
   @doc """
   Signs the user in by redirecting to the GitHub authorization URL.

--- a/lib/atom_tweaks_web/controllers/page_controller.ex
+++ b/lib/atom_tweaks_web/controllers/page_controller.ex
@@ -1,7 +1,7 @@
 defmodule AtomTweaksWeb.PageController do
   use AtomTweaksWeb, :controller
 
-  alias AtomTweaksWeb.Tweak
+  alias AtomTweaks.Tweak
 
   def index(conn, params) do
     query =

--- a/lib/atom_tweaks_web/controllers/tweak_controller.ex
+++ b/lib/atom_tweaks_web/controllers/tweak_controller.ex
@@ -3,8 +3,8 @@ defmodule AtomTweaksWeb.TweakController do
 
   alias AtomTweaksWeb.ErrorView
   alias AtomTweaksWeb.PageMetadata
-  alias AtomTweaksWeb.Tweak
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.Tweak
+  alias AtomTweaks.User
 
   require Logger
 

--- a/lib/atom_tweaks_web/controllers/user_controller.ex
+++ b/lib/atom_tweaks_web/controllers/user_controller.ex
@@ -1,8 +1,8 @@
 defmodule AtomTweaksWeb.UserController do
   use AtomTweaksWeb, :controller
 
-  alias AtomTweaksWeb.Tweak
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.Tweak
+  alias AtomTweaks.User
 
   def show(conn, %{"id" => name}) do
     case Repo.get_by(User, name: name) do

--- a/lib/atom_tweaks_web/markdown_engine.ex
+++ b/lib/atom_tweaks_web/markdown_engine.ex
@@ -4,7 +4,7 @@ defmodule AtomTweaksWeb.MarkdownEngine do
 
   Used both directly and within Slime templates.
   """
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.User
 
   @behaviour Slime.Parser.EmbeddedEngine
 

--- a/lib/atom_tweaks_web/router.ex
+++ b/lib/atom_tweaks_web/router.ex
@@ -6,8 +6,6 @@ defmodule AtomTweaksWeb.Router do
 
   alias AtomTweaksWeb.HerokuMetadata
   alias AtomTweaksWeb.SlidingSessionTimeout
-  alias Phoenix.Router.NoRouteError
-  alias Plug.Conn
 
   pipeline :browser do
     plug(:accepts, ["html"])
@@ -74,28 +72,28 @@ defmodule AtomTweaksWeb.Router do
     conn
   end
 
-  defp handle_errors(_, %{kind: :error, reason: %NoRouteError{}}), do: :ok
-
-  defp handle_errors(conn, %{kind: kind, reason: reason, stack: stacktrace}) do
-    conn =
-      conn
-      |> Conn.fetch_cookies()
-      |> Conn.fetch_query_params()
-
-    conn_data = %{
-      "request" => %{
-        "cookies" => conn.req_cookies,
-        "url" => "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
-        "user_ip" => conn.remote_ip |> Tuple.to_list() |> Enum.join("."),
-        "headers" => Enum.into(conn.req_headers, %{}),
-        "params" => conn.params,
-        "method" => conn.method
-      },
-      "server" => %{
-        "pid" => System.get_env("MY_SERVER_PID"),
-        "host" => "#{System.get_env("MY_HOSTNAME")}:#{System.get_env("MY_PORT")}",
-        "root" => System.get_env("MY_APPLICATION_PATH")
-      }
-    }
-  end
+  # defp handle_errors(_, %{kind: :error, reason: %NoRouteError{}}), do: :ok
+  #
+  # defp handle_errors(conn, %{kind: _kind, reason: _reason, stack: _stacktrace}) do
+  #   conn =
+  #     conn
+  #     |> Conn.fetch_cookies()
+  #     |> Conn.fetch_query_params()
+  #
+  #   conn_data = %{
+  #     "request" => %{
+  #       "cookies" => conn.req_cookies,
+  #       "url" => "#{conn.scheme}://#{conn.host}:#{conn.port}#{conn.request_path}",
+  #       "user_ip" => conn.remote_ip |> Tuple.to_list() |> Enum.join("."),
+  #       "headers" => Enum.into(conn.req_headers, %{}),
+  #       "params" => conn.params,
+  #       "method" => conn.method
+  #     },
+  #     "server" => %{
+  #       "pid" => System.get_env("MY_SERVER_PID"),
+  #       "host" => "#{System.get_env("MY_HOSTNAME")}:#{System.get_env("MY_PORT")}",
+  #       "root" => System.get_env("MY_APPLICATION_PATH")
+  #     }
+  #   }
+  # end
 end

--- a/lib/atom_tweaks_web/views/avatar_helpers.ex
+++ b/lib/atom_tweaks_web/views/avatar_helpers.ex
@@ -5,7 +5,7 @@ defmodule AtomTweaksWeb.AvatarHelpers do
 
   use Phoenix.HTML
 
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.User
 
   @doc """
   Displays the avatar for the `user`.

--- a/lib/atom_tweaks_web/views/octicon_helpers.ex
+++ b/lib/atom_tweaks_web/views/octicon_helpers.ex
@@ -5,7 +5,7 @@ defmodule AtomTweaksWeb.OcticonHelpers do
 
   use Phoenix.HTML
 
-  alias AtomTweaksWeb.Tweak
+  alias AtomTweaks.Tweak
 
   @doc """
   Draws the appropriate Octicon for the given `tweak`.

--- a/lib/atom_tweaks_web/views/render_helpers.ex
+++ b/lib/atom_tweaks_web/views/render_helpers.ex
@@ -6,7 +6,7 @@ defmodule AtomTweaksWeb.RenderHelpers do
 
   use Phoenix.HTML
 
-  alias AtomTweaksWeb.Tweak
+  alias AtomTweaks.Tweak
 
   @doc """
   Renders the code for the given `tweak`.

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -11,8 +11,8 @@
 # and so on) as they will fail if something goes wrong.
 
 alias AtomTweaks.Repo
-alias AtomTweaksWeb.Tweak
-alias AtomTweaksWeb.User
+alias AtomTweaks.Tweak
+alias AtomTweaks.User
 
 if System.get_env("MIX_ENV") != "test" do
   users = [

--- a/test/atom_tweaks/tweak_test.exs
+++ b/test/atom_tweaks/tweak_test.exs
@@ -1,7 +1,7 @@
 defmodule AtomTweaks.TweakTest do
   use AtomTweaks.DataCase
 
-  alias AtomTweaksWeb.Tweak
+  alias AtomTweaks.Tweak
 
   def build_tweak(user, params \\ []) do
     Tweak.changeset(%Tweak{}, params_for(:tweak, [user: user] ++ params))

--- a/test/atom_tweaks/user_test.exs
+++ b/test/atom_tweaks/user_test.exs
@@ -1,7 +1,7 @@
 defmodule AtomTweaks.UserTest do
   use AtomTweaks.DataCase
 
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.User
 
   def build_user(params \\ []) do
     User.changeset(%User{}, params_for(:user, params))

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,8 +5,8 @@ defmodule AtomTweaks.Factory do
 
   alias AtomTweaks.Markdown
 
-  alias AtomTweaksWeb.Tweak
-  alias AtomTweaksWeb.User
+  alias AtomTweaks.Tweak
+  alias AtomTweaks.User
 
   def user_factory do
     %User{


### PR DESCRIPTION
Phoenix v1.3 doesn't use models anymore, so this is pulling out the last vestiges of Phoenix v1.2.x design in preparation for implementing #3.