### PR TITLE
Handle status 400 and 422 in the ErrorView

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ elixir:
 otp_release:
   - 20.0
 
-branches:
-  only:
-  - master
-
 dist: trusty
 sudo: false
 addons:

--- a/lib/atom_tweaks_web/views/error_view.ex
+++ b/lib/atom_tweaks_web/views/error_view.ex
@@ -4,6 +4,8 @@ defmodule AtomTweaksWeb.ErrorView do
   """
   use AtomTweaksWeb, :view
 
+  require Logger
+
   @doc """
   Renders the page for the given template.
 
@@ -16,7 +18,9 @@ defmodule AtomTweaksWeb.ErrorView do
 
   # In case no render clause matches or no
   # template is found, let's render it as 500
-  def template_not_found(_template, assigns) do
+  def template_not_found(template, assigns) do
+    Logger.info(fn -> "No handler for #{template}" end)
+
     render("500.html", assigns)
   end
 end

--- a/lib/atom_tweaks_web/views/error_view.ex
+++ b/lib/atom_tweaks_web/views/error_view.ex
@@ -1,13 +1,17 @@
 defmodule AtomTweaksWeb.ErrorView do
+  @doc """
+  View functions for HTTP error states.
+  """
   use AtomTweaksWeb, :view
 
-  def render("404.html", _assigns) do
-    "Page not found"
-  end
+  @doc """
+  Renders the page for the given template.
 
-  def render("500.html", _assigns) do
-    "Internal server error"
-  end
+  Since we don't have fancy error pages yet, we're just rendering the text of the status code.
+  """
+  def render("404.html", _assigns), do: "Page not found"
+  def render("422.html", _assigns), do: "Unprocessable entity"
+  def render("500.html", _assigns), do: "Internal server error"
 
   # In case no render clause matches or no
   # template is found, let's render it as 500

--- a/lib/atom_tweaks_web/views/error_view.ex
+++ b/lib/atom_tweaks_web/views/error_view.ex
@@ -9,6 +9,7 @@ defmodule AtomTweaksWeb.ErrorView do
 
   Since we don't have fancy error pages yet, we're just rendering the text of the status code.
   """
+  def render("400.html", _assigns), do: "Bad request"
   def render("404.html", _assigns), do: "Page not found"
   def render("422.html", _assigns), do: "Unprocessable entity"
   def render("500.html", _assigns), do: "Internal server error"


### PR DESCRIPTION
This prevents them from getting translated into obscure "Internal server error" messages.

Fixes #90 