### PR TITLE
Override default Phoenix buildpack compile step

### DIFF
--- a/compile
+++ b/compile
@@ -1,0 +1,9 @@
+cd $phoenix_dir
+
+npm --prefix ./assets run deploy
+
+mix "${phoenix_ex}.digest"
+
+if mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; then
+  mix "${phoenix_ex}.digest.clean"
+fi


### PR DESCRIPTION
Because assets are being built in a new way, the [Phoenix Heroku buildpack](https://github.com/gjaldon/heroku-buildpack-phoenix-static) needs to be told how to compile them.