### PR TITLE
Make the title size match GitHub issue lists

### DIFF
--- a/assets/css/lists.scss
+++ b/assets/css/lists.scss
@@ -1,4 +1,4 @@
 a.title {
-  font-size: 1.5rem;
+  font-size: $h4-size;
   font-weight: bold;
 }


### PR DESCRIPTION
This has kind of bugged me but I didn't have time to figure it out until now 😀 