### PR TITLE
Flash the new token code

### DIFF
--- a/assets/css/code.scss
+++ b/assets/css/code.scss
@@ -1,6 +1,10 @@
 tt,
 code {
   font-size: $body-font-size;
+
+  &.force-wrap {
+    word-wrap: break-word;
+  }
 }
 
 .hljs-comment,

--- a/lib/atom_tweaks_web/controllers/token_controller.ex
+++ b/lib/atom_tweaks_web/controllers/token_controller.ex
@@ -29,8 +29,10 @@ defmodule AtomTweaksWeb.TokenController do
     changeset = Token.changeset(%Token{}, params)
 
     case Repo.insert(changeset) do
-      {:ok, _token} ->
-        redirect(conn, to: Routes.user_token_path(conn, :index, user))
+      {:ok, token} ->
+        conn
+        |> put_flash(:token_code, Token.to_code(token))
+        |> redirect(to: Routes.user_token_path(conn, :index, user))
 
       {:error, changeset} ->
         star_count = Accounts.count_stars(user)

--- a/lib/atom_tweaks_web/templates/token/_table_row.html.slime
+++ b/lib/atom_tweaks_web/templates/token/_table_row.html.slime
@@ -6,5 +6,3 @@
       .float-right.px-2
         = link to: Routes.user_token_path(@conn, :delete, @user, @token), method: :delete do
           = octicon(:x)
-      .float-right
-        = @token.id

--- a/lib/atom_tweaks_web/templates/token/index.html.slime
+++ b/lib/atom_tweaks_web/templates/token/index.html.slime
@@ -7,5 +7,9 @@
       = octicon(:"credit-card")
       spam.px-1
       = gettext "New"
+  = if get_flash(@conn, :token_code) do
+    .flash.mb-3 role="alert"
+      p = gettext("Record this code, it will only be shown once:")
+      code.force-wrap = get_flash(@conn, :token_code)
   .Box
     = render_many_or_blank(@tokens, @view_module, "_table_row.html", "_blankslate.html", Map.put(assigns, :as, :token))


### PR DESCRIPTION
The token ID doesn't help because the API requires the token code so it can be verified.

## Release notes

### Admin-only changes

* Fixed the display of new tokens