### PR TITLE
Order release notes by default newest first

### DIFF
--- a/lib/atom_tweaks/releases.ex
+++ b/lib/atom_tweaks/releases.ex
@@ -84,15 +84,25 @@ defmodule AtomTweaks.Releases do
   @doc """
   Returns the list of notes.
 
+  ## Options
+
+  * `:order_by` -- Passed to `Ecto.Query.order_by/3`
+
   ## Examples
+
+  List release notes with newest first:
 
   ```
   iex> list_notes()
   [%Note{}, ...]
   ```
   """
-  def list_notes do
-    Repo.all(Note)
+  def list_notes(options \\ []) do
+    order = Keyword.get(options, :order_by, desc: :inserted_at)
+
+    Note
+    |> order_by(^order)
+    |> Repo.all()
   end
 
   @doc """

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -296,3 +296,8 @@ msgstr ""
 #: lib/atom_tweaks_web/templates/token/_blankslate.html.slime:1
 msgid "You haven't created any tokens yet."
 msgstr ""
+
+#, elixir-format
+#: lib/atom_tweaks_web/templates/token/index.html.slime:1
+msgid "Record this code, it will only be shown once:"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -297,3 +297,8 @@ msgstr ""
 #: lib/atom_tweaks_web/templates/token/_blankslate.html.slime:1
 msgid "You haven't created any tokens yet."
 msgstr ""
+
+#, elixir-format
+#: lib/atom_tweaks_web/templates/token/index.html.slime:1
+msgid "Record this code, it will only be shown once:"
+msgstr ""

--- a/priv/gettext/ps/LC_MESSAGES/default.po
+++ b/priv/gettext/ps/LC_MESSAGES/default.po
@@ -297,3 +297,8 @@ msgstr "Ṫṓḳḛṇṡ"
 #: lib/atom_tweaks_web/templates/token/_blankslate.html.slime:1
 msgid "You haven't created any tokens yet."
 msgstr "Ŷṓṵ ḥαṽḛṇ'ṭ ͼṛḛαṭḛḍ αṇẏ ṭṓḳḛṇṡ ẏḛṭ."
+
+#, elixir-format
+#: lib/atom_tweaks_web/templates/token/index.html.slime:1
+msgid "Record this code, it will only be shown once:"
+msgstr "Ṛḛͼṓṛḍ ṭḥḭṡ ͼṓḍḛ, ḭṭ ẁḭḽḽ ṓṇḽẏ ḅḛ ṡḥṓẁṇ ṓṇͼḛ:"

--- a/test/atom_tweaks/releases_test.exs
+++ b/test/atom_tweaks/releases_test.exs
@@ -22,6 +22,14 @@ defmodule AtomTweaks.ReleasesTest do
       assert Releases.list_notes() == [render_md(note)]
     end
 
+    test "list_notes/0 orders release notes newest first", _context do
+      third = insert(:note)
+      second = insert(:note)
+      first = insert(:note)
+
+      assert Releases.list_notes() == Enum.map([first, second, third], &render_md/1)
+    end
+
     test "get_note!/1 returns the note with given id" do
       note = insert(:note)
 


### PR DESCRIPTION
Fixes #424 

## Release notes

* Fix release notes order by placing newest notes first