### PR TITLE
Use user type instead of labels to choose whether to extract notes

### DIFF
--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Extract release notes
       id: extract
       uses: lee-dohm/extract-release-notes@master
-      if: "github.event.pull_request.merged && ! contains(join(github.event.pull_request.labels.*.name), 'dependencies')"
+      if: github.event.pull_request.merged && github.event.pull_request.user.type != "Bot"
     - name: Post release notes
       uses: ./.github/actions/post-release-notes
       if: github.event.pull_request.merged && job.steps.extract.status == success()

--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Extract release notes
       id: extract
       uses: lee-dohm/extract-release-notes@master
-      if: github.event.pull_request.merged && github.event.pull_request.user.type != "Bot"
+      if: "github.event.pull_request.merged && github.event.pull_request.user.type != 'Bot'"
     - name: Post release notes
       uses: ./.github/actions/post-release-notes
       if: github.event.pull_request.merged && job.steps.extract.status == success()

--- a/.github/workflows/validate-release-notes.yml
+++ b/.github/workflows/validate-release-notes.yml
@@ -6,10 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: DEBUG labels
-      env:
-        LABELS: ${{ join(github.event.pull_request.labels.*.name) }}
-      run: echo "LABELS = $LABELS"
     - name: Extract release notes
       uses: lee-dohm/extract-release-notes@master
-      if: "! contains(join(github.event.pull_request.labels.*.name), 'dependencies')"
+      if: github.event.pull_request.user.type != "Bot"

--- a/.github/workflows/validate-release-notes.yml
+++ b/.github/workflows/validate-release-notes.yml
@@ -8,4 +8,4 @@ jobs:
     - uses: actions/checkout@master
     - name: Extract release notes
       uses: lee-dohm/extract-release-notes@master
-      if: github.event.pull_request.user.type != "Bot"
+      if: "github.event.pull_request.user.type != 'Bot'"


### PR DESCRIPTION
Because @dependabot doesn't apply the labels until after the pull request is created, I need to key off of the user type instead of whether or not the `dependencies` label is applied. Because of the lack of labels on the pull request event payload, the first run of validate release notes always fails but successive ones pass.

Changed the logic on the post release notes workflow to match for consistency.

## Release notes

None