### PR TITLE
Run post release notes workflow only when a PR is closed and merged

### DIFF
--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -1,4 +1,5 @@
 on: pull_request
+  types: [closed]
 name: Post release notes
 jobs:
   postReleaseNotes:
@@ -6,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+      if: github.event.pull_request.merged
     - name: Extract release notes
       id: extract
       uses: lee-dohm/extract-release-notes@master

--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -1,5 +1,6 @@
-on: pull_request
-  types: [closed]
+on:
+  pull_request:
+    types: [closed]
 name: Post release notes
 jobs:
   postReleaseNotes:


### PR DESCRIPTION
Fixes #527 

## Release notes

* Fixed the post release notes action to run when a PR is merged