### PR TITLE
Use head ref for checkout

### DIFF
--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -7,7 +7,9 @@ jobs:
     name: Post release notes
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1.0.0
+      with:
+        ref: refs/heads/${{ github.head_ref }}
       if: github.event.pull_request.merged
     - name: Extract release notes
       id: extract


### PR DESCRIPTION
Fixes #527 

## Release notes

* Fixed the post release notes action to run when a PR is merged