### PR TITLE
Use the SHA for checkout not branch name

### DIFF
--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1.0.0
       with:
-        ref: refs/heads/${{ github.head_ref }}
+        ref: ${{ github.sha }}
       if: github.event.pull_request.merged
     - name: Extract release notes
       id: extract


### PR DESCRIPTION
Using the branch name for the actions/checkout step requires that the branch still exist when the pull request is merged and closed. This prevents us from using the new "delete branch on merge" feature that keeps the list of branches in the repository nice and tidy.

Using the SHA instead of the branch name will allow us to use the feature and means we don't have to manually go back and delete the branches after the workflow has completed.

## Release notes

false