### PR TITLE
Use SHA since the branch gets deleted by dependabot

### DIFF
--- a/.github/workflows/post-release-notes.yml
+++ b/.github/workflows/post-release-notes.yml
@@ -7,9 +7,9 @@ jobs:
     name: Post release notes
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1.0.0
+    - uses: actions/checkout@v2
       with:
-        ref: refs/heads/${{ github.head_ref }}
+        ref: ${{ env.GITHUB_SHA }}
       if: github.event.pull_request.merged
     - name: Extract release notes
       id: extract


### PR DESCRIPTION
When merging a dependabot-generated PR, the post-release-notes workflow always fails, which generates an annoying email. It's not a big deal because the post-release-notes workflow is not supposed to succeed for bot-generated PRs, but the email is still annoying.

This should fix the email thing.

## Release notes

None