### PR TITLE
Standardize the actions README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Atom Tweaks
 
-[![Travis](https://img.shields.io/travis/lee-dohm/atom-style-tweaks.svg)](https://travis-ci.org/lee-dohm/atom-style-tweaks)
+[![Build](https://github.com/lee-dohm/atom-style-tweaks/workflows/build/badge.svg)](https://github.com/lee-dohm/atom-style-tweaks/actions?query=workflow%3Abuild)
 [![Coverage Status](https://coveralls.io/repos/github/lee-dohm/atom-style-tweaks/badge.svg?branch=master)](https://coveralls.io/github/lee-dohm/atom-style-tweaks?branch=master)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=lee-dohm/atom-style-tweaks)](https://dependabot.com)
-[![Publish docs](https://github.com/lee-dohm/atom-style-tweaks/workflows/Publish%20docs/badge.svg)](https://www.lee-dohm.com/atom-style-tweaks/)
+[![Publish docs](https://github.com/lee-dohm/atom-style-tweaks/workflows/Publish%20docs/badge.svg)](https://github.com/lee-dohm/atom-style-tweaks/actions?query=workflow%3A%22Publish+docs%22)
 [![SourceLevel](https://app.sourcelevel.io/github/lee-dohm/atom-style-tweaks.svg)](https://app.sourcelevel.io/github/lee-dohm/atom-style-tweaks)
 
 [A website](https://www.atom-tweaks.com) for collecting various simple tweaks for your [Atom editor](https://atom.io) environment.


### PR DESCRIPTION
* Make the build badge point to the build workflow instead of Travis
* Make the badges link to the status page for that badge's workflow

## Release notes

None