### PR TITLE
Add synchronized pull requests to validate release notes

### DIFF
--- a/.github/workflows/validate-release-notes.yml
+++ b/.github/workflows/validate-release-notes.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronized]
 name: Validate release notes
 jobs:
   validateReleaseNotes:


### PR DESCRIPTION
When pull requests are force-pushed, they would never update their validate release notes workflow and would need to be force merged by an administrator. This should fix that.

## Release notes

None