### PR TITLE
Add 'none' to the list of negative release note patterns

### DIFF
--- a/.github/actions/post-release-notes/bin/validate-release-notes
+++ b/.github/actions/post-release-notes/bin/validate-release-notes
@@ -11,7 +11,8 @@ contents =
 no_notes_patterns =
   [
     ~R/\Afalse\z/im,
-    ~R/\Ano(\s+release)?\s+note(s)?\z/im
+    ~R/\Ano(\s+release)?\s+note(s)?\z/im,
+    ~R/\Anone\z/im
   ]
 
 if Enum.any?(no_notes_patterns, fn pattern -> contents =~ pattern end) do


### PR DESCRIPTION
Recognizes "None" as a pattern that should not post release notes.

## Release notes

None
