### PR TITLE
Exit successfully when there are intentionally no release notes

### DIFF
--- a/.github/actions/post-release-notes/entrypoint.sh
+++ b/.github/actions/post-release-notes/entrypoint.sh
@@ -21,6 +21,11 @@ fi
 
 /validate-release-notes "$file_path"
 
+if [ $? -eq 78 ]; then
+  echo "Success: Valid release notes section intentionally containing no release notes"
+  exit 0
+fi
+
 title=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
 detail_url=$(jq --raw-output .pull_request.html_url "$GITHUB_EVENT_PATH")
 


### PR DESCRIPTION
Fixes the issue where the publish release notes workflow fails when there are intentionally no release notes to post.

## Release notes

None
